### PR TITLE
feat: add LED wall wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ Deploy the `dist/` folder to any web server.
 ?type=ledwall&displayRows=5&server=192.168.1.50:27123
 ```
 
+## LED Wall Wrapper
+
+For LED walls where the controller crops a portion of the HDMI signal, a standalone wrapper is included at `/ledwall.html`. It places content in an iframe with exact pixel dimensions matching the physical panel:
+
+```
+http://[server]/ledwall.html?width=768&height=384
+```
+
+Without a `url` parameter, it loads the scoreboard automatically. Use `url` to wrap other content (H2R Graphics, etc.):
+
+```
+http://[server]/ledwall.html?url=http://other-source:8080/output&width=768&height=384
+```
+
+See [docs/ledwall-wrapper.md](docs/ledwall-wrapper.md) for details.
+
 ## Layout Modes
 
 ### Vertical (Portrait)
@@ -221,6 +237,7 @@ public/
 - [docs/timing.md](docs/timing.md) - Timing constants
 - [docs/troubleshooting.md](docs/troubleshooting.md) - Problem solving
 - [docs/SolvingBR1BR2.md](docs/SolvingBR1BR2.md) - BR1/BR2 merge details
+- [docs/ledwall-wrapper.md](docs/ledwall-wrapper.md) - LED wall wrapper usage
 
 ## License
 

--- a/docs/ledwall-wrapper.md
+++ b/docs/ledwall-wrapper.md
@@ -1,0 +1,101 @@
+# LED Wall Wrapper
+
+A standalone HTML utility for displaying web content on LED walls with exact pixel dimensions.
+
+## The Problem
+
+LED wall setups typically work like this:
+
+1. A source device (e.g. Raspberry Pi) outputs a standard HDMI signal (e.g. 1920×1080)
+2. The LED wall controller card **crops the top-left corner** of the HDMI input — only the area matching the physical panel size is displayed (e.g. 768×384 pixels)
+3. The browser on the source device has **no way to detect** the actual LED panel dimensions — it sees the full HDMI resolution as its viewport
+
+This means the scoreboard (or any other content) renders for the full 1920×1080 viewport, but only a small portion is visible on the LED wall.
+
+## The Solution
+
+The LED wall wrapper places content inside an iframe with **exact pixel dimensions** matching the physical LED panel, positioned at coordinates (0,0). The rest of the screen is black. The LED wall controller crops the HDMI signal and gets exactly the right content.
+
+```
+┌─────────────────────────────────┐
+│ ┌───────────────┐               │
+│ │  LED content  │               │
+│ │  (iframe)     │   Black       │
+│ └───────────────┘               │
+│                                 │
+│           Black                 │
+│                                 │
+└─────────────────────────────────┘
+  Full HDMI output (e.g. 1920×1080)
+```
+
+## Usage
+
+The wrapper is deployed alongside the scoreboard at `/ledwall.html`.
+
+### Basic — Scoreboard
+
+Open in the browser on the source device:
+
+```
+http://[server]/ledwall.html?width=768&height=384
+```
+
+Without a `url` parameter, the wrapper automatically loads the scoreboard from the same server with `?type=ledwall&displayRows=5`.
+
+### Custom URL — Scoreboard with Parameters
+
+```
+http://[server]/ledwall.html?url=http://[server]/?type=ledwall%26displayRows=8%26server=192.168.1.50:27123&width=768&height=384
+```
+
+### Custom URL — Other Content (H2R Graphics, etc.)
+
+The wrapper is not scoreboard-specific. Use it with any web content:
+
+```
+http://[server]/ledwall.html?url=http://192.168.1.100:8080/output&width=768&height=384
+```
+
+This is useful when switching between scoreboard and other content (race info, promotions) using tools like H2R Graphics — all content needs to be wrapped to the correct panel dimensions.
+
+## URL Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `url` | Content URL to display | Scoreboard on same origin |
+| `width` | Panel width in pixels | `1280` |
+| `height` | Panel height in pixels | `720` |
+
+## Setup with Raspberry Pi (FullPageOS)
+
+1. Build and deploy `dist/` to a web server (or serve locally)
+2. Set the URL in `/boot/firmware/fullpageos.txt`:
+   ```
+   http://[webserver]/ledwall.html?width=768&height=384
+   ```
+3. Reboot — the browser opens fullscreen, content renders in the top-left corner
+
+## Common Panel Sizes
+
+| Panel | Wrapper URL |
+|-------|-------------|
+| 768×384 | `?width=768&height=384` |
+| 960×320 | `?width=960&height=320` |
+| 1280×640 | `?width=1280&height=640` |
+| 1920×480 | `?width=1920&height=480` |
+
+Consult your LED wall controller documentation for the exact input resolution it expects.
+
+## Troubleshooting
+
+**Content not visible on LED wall**
+- Verify the `width` and `height` parameters match the LED controller's input resolution
+- Make sure the HDMI output resolution of the source device is larger than the panel size
+
+**Content loads but looks wrong**
+- The scoreboard's `displayRows` parameter controls how many rows are shown — adjust to fit the panel height
+- Check that `?type=ledwall` is set on the scoreboard URL
+
+**Cross-origin issues**
+- If wrapping content from a different server, ensure it allows iframe embedding (no `X-Frame-Options: DENY`)

--- a/public/ledwall.html
+++ b/public/ledwall.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LED Wall Wrapper</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #000000;
+            overflow: hidden;
+        }
+        #content-frame {
+            position: absolute;
+            top: 0;
+            left: 0;
+            border: none;
+        }
+    </style>
+</head>
+<body>
+    <iframe id="content-frame" title="LED Wall Content"></iframe>
+
+    <script>
+        (function() {
+            var defaultWidth = '1280';
+            var defaultHeight = '720';
+
+            var urlParams = new URLSearchParams(window.location.search);
+            var contentUrl = urlParams.get('url') || '';
+            var width = urlParams.get('width') || defaultWidth;
+            var height = urlParams.get('height') || defaultHeight;
+
+            var iframe = document.getElementById('content-frame');
+            iframe.width = width;
+            iframe.height = height;
+
+            if (!contentUrl) {
+                // Default: load scoreboard from same origin
+                contentUrl = window.location.origin
+                    + window.location.pathname.replace(/\/ledwall\.html$/, '/')
+                    + '?type=ledwall&displayRows=5';
+            }
+
+            // Cache-busting to prevent stale content
+            var cacheBuster = 'cache=' + Date.now();
+            var separator = contentUrl.includes('?') ? '&' : '?';
+            iframe.src = contentUrl + separator + cacheBuster;
+        })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add standalone `ledwall.html` utility deployed to `dist/` alongside the scoreboard
- Wraps any web content (scoreboard, H2R Graphics, etc.) in an iframe with exact pixel dimensions matching the physical LED panel
- Solves the problem where the browser sees full HDMI resolution but the LED controller only crops the top-left corner
- Documentation at `docs/ledwall-wrapper.md`, referenced from README

## How it works

```
┌─────────────────────────────────┐
│ ┌───────────────┐               │
│ │  LED content  │               │
│ │  (iframe)     │   Black       │
│ └───────────────┘               │
│                                 │
│           Black                 │
└─────────────────────────────────┘
  Full HDMI output (e.g. 1920×1080)
```

Usage: `http://[server]/ledwall.html?width=768&height=384`

Without `url` parameter, loads scoreboard from same origin automatically.

Closes #4

## Test plan

- [ ] `npm run build` succeeds and `dist/ledwall.html` exists
- [ ] Open `ledwall.html` in browser — iframe renders scoreboard in top-left corner
- [ ] Test with `?width=400&height=300` — iframe matches specified dimensions
- [ ] Test with custom `?url=` — loads external content correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)