### PR TITLE
chore: upgrade TypeScript 5.9 to 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "globals": "^17.4.0",
         "jsdom": "^29.0.1",
         "tsx": "^4.19.0",
-        "typescript": "~5.9.3",
+        "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.0",
         "vite": "^7.3.1",
         "vitest": "^4.1.2",
@@ -4090,9 +4090,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "globals": "^17.4.0",
     "jsdom": "^29.0.1",
     "tsx": "^4.19.0",
-    "typescript": "~5.9.3",
+    "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.0",
     "vite": "^7.3.1",
     "vitest": "^4.1.2",

--- a/src/providers/utils/__tests__/br1br2Merger.test.ts
+++ b/src/providers/utils/__tests__/br1br2Merger.test.ts
@@ -349,7 +349,7 @@ describe('br1br2Merger', () => {
       const cache = new Map<string, CachedBR2Data>([
         ['1', {
           run1: { total: '85.00', pen: 0, rank: 1, status: '' },
-          run2: { total: '91.00', pen: 4, rank: 2, status: '*' },
+          run2: { total: '91.00', pen: 4, rank: 2, status: '', underInvestigation: true },
         }],
       ])
 

--- a/src/providers/utils/br1br2Merger.ts
+++ b/src/providers/utils/br1br2Merger.ts
@@ -230,7 +230,7 @@ export function mergeBR1CacheIntoBR2Results(
         pen: br2Pen,
         rank: result.rank,
         status: '',
-        underInvestigation: cachedRun2?.status === '*',
+        underInvestigation: cachedRun2?.underInvestigation ?? false,
       }
     } else if (cachedRun2) {
       // No live time, but cache has data (competitor ran earlier)

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -25,16 +25,15 @@
     "noUncheckedSideEffectImports": true,
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@/components/*": ["src/components/*"],
-      "@/context/*": ["src/context/*"],
-      "@/providers/*": ["src/providers/*"],
-      "@/hooks/*": ["src/hooks/*"],
-      "@/styles/*": ["src/styles/*"],
-      "@/types/*": ["src/types/*"],
-      "@/utils/*": ["src/utils/*"]
+      "@/*": ["./src/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/context/*": ["./src/context/*"],
+      "@/providers/*": ["./src/providers/*"],
+      "@/hooks/*": ["./src/hooks/*"],
+      "@/styles/*": ["./src/styles/*"],
+      "@/types/*": ["./src/types/*"],
+      "@/utils/*": ["./src/utils/*"]
     }
   },
   "include": ["src"],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -22,11 +22,10 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@/providers/*": ["src/providers/*"],
-      "@/types/*": ["src/types/*"]
+      "@/*": ["./src/*"],
+      "@/providers/*": ["./src/providers/*"],
+      "@/types/*": ["./src/types/*"]
     }
   },
   "include": ["src/test-utils/**/*.ts"]


### PR DESCRIPTION
## Summary
- Upgrade TypeScript from 5.9.3 to 6.0.2
- Remove deprecated `baseUrl` from tsconfig files, add `./` prefix to paths values
- Fix type-incorrect `cachedRun2?.status === '*'` check (TS6 correctly caught this as dead code — `status` type doesn't include `'*'`), replaced with `cachedRun2?.underInvestigation`

## Test plan
- [x] `tsc -b` passes cleanly
- [x] All 734 tests pass
- [x] Lint clean (only pre-existing warnings)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)