### PR TITLE
fix: reset lastTopShownAt after scrollToTop in highlight-end

### DIFF
--- a/src/hooks/useAutoScroll.ts
+++ b/src/hooks/useAutoScroll.ts
@@ -281,13 +281,16 @@ export function useAutoScroll(config: AutoScrollConfig = {}): UseAutoScrollRetur
         } else {
           scrollToTop()
           currentRowIndexRef.current = 0
+          // Top is now visible again — reset the "last top shown" marker so
+          // the next finish within BROWSE_TOP_THRESHOLD can trigger browse scroll.
+          updateLastTopShown()
           setPhase('IDLE')
         }
       }, 500) // Small delay for highlight to fade
 
       return () => clearTimeout(timeoutId)
     }
-  }, [isHighlightActive, phase, scrollToTop, layoutMode, browseAfterHighlight, prefersReducedMotion])
+  }, [isHighlightActive, phase, scrollToTop, layoutMode, browseAfterHighlight, prefersReducedMotion, updateLastTopShown])
 
   /**
    * Main auto-scroll state machine


### PR DESCRIPTION
## Summary

Closes #55

Fixes a regression in #53 (browse-after-highlight on ledwall): the feature silently stopped working after 3 minutes from page load because `lastTopShownAt` never got reset in the only code path that actually ran on ledwall.

## Root cause

- `lastTopShownAt` is initialized on mount.
- It is updated only in `RETURNING_TO_TOP`, `SCROLLING_TO_TOP_FOR_COMPETITOR`, and `BROWSE_PAUSED_AT_BOTTOM` phases.
- On ledwall with an actively running competitor (typical for interval racing), `shouldScroll=false`, so the auto-scroll cycle that would trigger `RETURNING_TO_TOP` never runs.
- The fallback `else` branch of the highlight-end effect called `scrollToTop()` but did **not** update the marker.
- After `Date.now() - lastTopShownAt > 3 min`, `shouldBrowse` is forever `false`.

## Fix

One line: call `updateLastTopShown()` after `scrollToTop()` in the fallback branch. Top is now visibly shown — the marker should reflect that.

## Test plan

- [x] `npm test` — 751/751 pass
- [x] `npm run build` — no TS errors
- [x] Manual verification on Saturday afternoon replay (`2026-04-18-jarni-so-odp`) with `?type=ledwall&displayRows=5&browseAfterHighlight=true`:
  - 20 `BROWSE_SCROLLING` activations over ~8 min (zero before the fix)
  - 11 unique highlighted competitors scrolled into view and then browse-scrolled
  - `shouldBrowse=true` reached repeatedly in normal interval-racing cadence

## Note on unrelated regression

During verification I observed a separate issue on category-transition: after a finish, `SET_RESULTS` for the correct raceId sometimes arrives >10 s later (server rotates through categories), which exceeds the `pendingHighlightTimestamp` window (10 s) — the highlight is then dropped entirely. Not caused by #53, but the user-visible effect is related. Will open a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)