### PR TITLE
fix: pin finisher to CurrentCompetitor for 8s (interval racing)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,13 +111,29 @@ function ScoreboardContent() {
         }
         footer={<Footer visible={visibility.displayFooter} imageUrl={assets.footerImageUrl} />}
       >
-        {/* Current competitor - shows departing if no current */}
+        {/* Current competitor.
+            Finishers (departing with dtFinish) take precedence over the next
+            on-course competitor for FINISH_DISPLAY_DURATION — ensures the
+            final time gets a visible pause during interval racing.
+            Non-finishers only fill in when currentCompetitor is null. */}
         <ErrorBoundary componentName="CurrentCompetitor">
-          <CurrentCompetitor
-            competitor={currentCompetitor ?? departingCompetitor}
-            visible={visibility.displayCurrent}
-            isDeparting={!currentCompetitor && !!departingCompetitor}
-          />
+          {(() => {
+            const finishingDeparture = departingCompetitor?.dtFinish
+              ? departingCompetitor
+              : null
+            const displayCompetitor =
+              finishingDeparture ?? currentCompetitor ?? departingCompetitor
+            const isDeparting =
+              !!finishingDeparture ||
+              (!currentCompetitor && !!departingCompetitor)
+            return (
+              <CurrentCompetitor
+                competitor={displayCompetitor}
+                visible={visibility.displayCurrent}
+                isDeparting={isDeparting}
+              />
+            )
+          })()}
         </ErrorBoundary>
 
 

--- a/src/context/ScoreboardContext.tsx
+++ b/src/context/ScoreboardContext.tsx
@@ -20,7 +20,12 @@ import type {
   EventInfoData,
   ProviderError,
 } from '@/providers/types'
-import { DEPARTING_TIMEOUT, FINISHED_GRACE_PERIOD, STALE_COMPETITOR_TIMEOUT } from './constants'
+import {
+  DEPARTING_TIMEOUT,
+  FINISH_DISPLAY_DURATION,
+  FINISHED_GRACE_PERIOD,
+  STALE_COMPETITOR_TIMEOUT,
+} from './constants'
 
 /**
  * Scoreboard state interface
@@ -223,8 +228,15 @@ function scoreboardReducer(
           newState.highlightTimestamp = Date.now()
           newState.pendingHighlightBib = null
           newState.pendingHighlightTimestamp = null
-          // Clear departing if this was the departing competitor
-          if (state.departingCompetitor?.bib === state.pendingHighlightBib) {
+          // Clear departing if this was the departing competitor.
+          // Exception: if the departing competitor has dtFinish, let the
+          // timeout path clear it so the finisher stays pinned in the
+          // CurrentCompetitor slot for the full FINISH_DISPLAY_DURATION
+          // instead of being cut short by the results update.
+          if (
+            state.departingCompetitor?.bib === state.pendingHighlightBib &&
+            !state.departingCompetitor?.dtFinish
+          ) {
             newState.departingCompetitor = null
             newState.departedAt = null
           }
@@ -424,10 +436,16 @@ function scoreboardReducer(
         newState.raceStatus = ''
       }
 
-      // Atomic departing update - if previous competitor exists and bib differs
+      // Atomic departing update - if previous competitor exists and bib differs.
+      // If the departing competitor just finished, prefer the version from
+      // newOnCourse (which has dtFinish + final time) over the stale prev copy.
+      // This allows App.tsx to pin finishers for FINISH_DISPLAY_DURATION.
       const prev = state.currentCompetitor
       if (prev && prev.bib !== newCurrent?.bib) {
-        newState.departingCompetitor = prev
+        const finishedVersion = newOnCourse.find(
+          c => c.bib === prev.bib && c.dtFinish
+        )
+        newState.departingCompetitor = finishedVersion ?? prev
         newState.departedAt = Date.now()
       }
 
@@ -653,15 +671,20 @@ export function ScoreboardProvider({
 
   /**
    * Departing competitor timeout effect
-   * Clears departing competitor after DEPARTING_TIMEOUT if no highlight arrives
+   * Finishers (dtFinish) stay for FINISH_DISPLAY_DURATION so the final time
+   * gets a visible pause in the CurrentCompetitor slot. Non-finishers clear
+   * after the shorter DEPARTING_TIMEOUT.
    */
   useEffect(() => {
     if (!state.departingCompetitor || !state.departedAt) {
       return
     }
 
+    const timeout = state.departingCompetitor.dtFinish
+      ? FINISH_DISPLAY_DURATION
+      : DEPARTING_TIMEOUT
     const elapsed = Date.now() - state.departedAt
-    const remaining = DEPARTING_TIMEOUT - elapsed
+    const remaining = timeout - elapsed
 
     const timeoutId = setTimeout(() => {
       dispatch({ type: 'CLEAR_DEPARTING' })

--- a/src/context/__tests__/ScoreboardContext.test.tsx
+++ b/src/context/__tests__/ScoreboardContext.test.tsx
@@ -437,7 +437,7 @@ describe('ScoreboardContext', () => {
       expect(result.current.departedAt).toBeNull()
     })
 
-    it('clears departing competitor when dtFinish highlight arrives for them', () => {
+    it('keeps finisher (dtFinish) as departing even when highlight arrives — cleared only by FINISH_DISPLAY_DURATION timeout so CurrentCompetitor stays pinned', () => {
       const mockProvider = createMockProvider()
       const wrapper = createWrapper(mockProvider)
 
@@ -467,7 +467,10 @@ describe('ScoreboardContext', () => {
         })
       })
 
-      // Results arrive - triggers actual highlight and clears departing
+      // Results arrive - triggers highlight, but departing must NOT be cleared
+      // for finishers (issue #57). The finisher stays pinned until the
+      // FINISH_DISPLAY_DURATION timeout fires so the final time gets a
+      // visible pause in CurrentCompetitor during interval racing.
       act(() => {
         mockProvider.triggerResults({
           results: [createResult({ bib: '42', total: '92.50' })],
@@ -479,9 +482,10 @@ describe('ScoreboardContext', () => {
 
       // Highlight should be active for 42
       expect(result.current.highlightBib).toBe('42')
-      // Departing should be cleared (42 was the one that triggered highlight)
-      expect(result.current.departingCompetitor).toBeNull()
-      expect(result.current.departedAt).toBeNull()
+      // Departing should still hold the finisher (with dtFinish)
+      expect(result.current.departingCompetitor?.bib).toBe('42')
+      expect(result.current.departingCompetitor?.dtFinish).toBe('2025-12-28T10:01:30')
+      expect(result.current.departedAt).not.toBeNull()
     })
   })
 

--- a/src/context/constants.ts
+++ b/src/context/constants.ts
@@ -16,6 +16,16 @@ export const HIGHLIGHT_DURATION = 5000
 export const DEPARTING_TIMEOUT = 3000
 
 /**
+ * Finish display duration in milliseconds (8 seconds)
+ *
+ * When a competitor finishes (dtFinish), they remain pinned to the
+ * CurrentCompetitor slot for this duration — even if another competitor
+ * is on course (interval racing). Ensures the finish moment has a
+ * visible pause with the final time, instead of being replaced instantly.
+ */
+export const FINISH_DISPLAY_DURATION = 8000
+
+/**
  * Grace period for finished competitors in onCourse list (5 seconds)
  * After dtFinish is detected, competitor stays visible for this duration
  * before being removed from the on-course display

--- a/src/hooks/__tests__/useDeparting.test.ts
+++ b/src/hooks/__tests__/useDeparting.test.ts
@@ -146,7 +146,7 @@ describe('useDeparting', () => {
     expect(result.current.timeRemaining).toBe(0)
   })
 
-  it('clears departing when dtFinish highlight arrives for that competitor', () => {
+  it('keeps finisher as departing when highlight arrives — cleared only by FINISH_DISPLAY_DURATION timeout (issue #57)', () => {
     let onCourseCallback: ((data: unknown) => void) | null = null
     let resultsCallback: ((data: unknown) => void) | null = null
 
@@ -198,11 +198,13 @@ describe('useDeparting', () => {
       }
     })
 
-    // comp42 is now departing (switched from current to finished)
-    // Departing is cleared when Results arrive and highlight triggers
+    // comp42 is now departing (switched from current to finished, has dtFinish)
     expect(result.current.departingCompetitor?.bib).toBe('42')
+    expect(result.current.departingCompetitor?.dtFinish).toBe('2025-01-01T10:01:30Z')
 
-    // Simulate Results arriving - this triggers highlight and clears departing
+    // Simulate Results arriving - triggers highlight, but departing must NOT
+    // be cleared for finishers (issue #57). Finisher stays pinned until
+    // FINISH_DISPLAY_DURATION elapses so the final time gets a visible pause.
     act(() => {
       if (resultsCallback) {
         resultsCallback({
@@ -215,8 +217,9 @@ describe('useDeparting', () => {
       }
     })
 
-    // Now departing should be cleared (highlight triggered via results)
-    expect(result.current.departingCompetitor).toBeNull()
+    // Departing still holds the finisher
+    expect(result.current.departingCompetitor?.bib).toBe('42')
+    expect(result.current.departingCompetitor?.dtFinish).toBe('2025-01-01T10:01:30Z')
   })
 
   it('calculates progress correctly over time', () => {


### PR DESCRIPTION
## Summary

- Extend the departing mechanism so finishers (`dtFinish`) take precedence over the next on-course competitor in the `CurrentCompetitor` slot
- New `FINISH_DISPLAY_DURATION = 8000` ms keeps the finisher pinned regardless of when results arrive
- Single-start pause grows from 3 s to 8 s as a side effect

## Why

Root cause (see issue for full research): `App.tsx` renders `currentCompetitor ?? departingCompetitor` — with interval racing the next runner is always on course, so `departingCompetitor` never wins and the finish time never gets a pause in the main slot. `departingCompetitor` also previously cleared the moment results arrived (~1–2 s), which would cut the new 8 s pause short — fixed by skipping that auto-clear for competitors with `dtFinish`.

## Changes

- `src/context/constants.ts` — add `FINISH_DISPLAY_DURATION`
- `src/context/ScoreboardContext.tsx`:
  - Departing capture now picks the finisher version from `newOnCourse` (with `dtFinish`) instead of the stale `prev` copy
  - `SET_RESULTS` keeps departing alive for finishers so the pause isn't cut short by incoming results
  - Timeout effect uses `FINISH_DISPLAY_DURATION` when the departing competitor has `dtFinish`
- `src/App.tsx` — finishing departing wins over `currentCompetitor`; non-finish departing keeps old semantics (fills in only when current is null)
- Tests updated to reflect the new hold-finisher semantics

## Test plan

- [x] All 751 unit tests pass locally
- [x] Manually verified with `2026-04-18-jarni-so-odp` replay (mid-afternoon, interval racing): finisher stays visible in main slot with final time, transitions to next competitor after ~8 s
- [ ] Watch on real ledwall during next race

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)