### PR TITLE
ci: upload dist as build artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
       # Tests disabled until test files are added
       # - name: Test
       #   run: npm run test -- --run


### PR DESCRIPTION
## Summary

- Mirrors the [c123-penalty-check CI setup](https://github.com/OpenCanoeTiming/c123-penalty-check/blob/main/.github/workflows/ci.yml) — after the build step, upload `dist/` as a named artifact with 7 days retention
- Artifact appears under the workflow run in the Actions tab; anyone can download a ready-to-serve bundle without a local build

## Why

Right now CI builds on every push/PR but throws the output away. Release Please creates a tag + CHANGELOG but attaches nothing, so test builds or ad-hoc deployments require a local checkout + `npm run build`. One small step solves the sharing path.

## Test plan

- [x] CI passes on this branch
- [x] `dist` artifact downloadable from the workflow run page

🤖 Generated with [Claude Code](https://claude.com/claude-code)