### PR TITLE
ci: attach built dist bundle as asset to GitHub releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,8 +11,52 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Runs only when a release was just created (i.e. the release PR was
+  # merged). Builds the production bundle and attaches it as a downloadable
+  # asset to the GitHub Release, so the scoreboard can be deployed without a
+  # local build. Source-only releases otherwise ship just GitHub's auto
+  # "Source code" archives.
+  attach-bundle:
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Package dist into zip
+        run: |
+          cd dist
+          zip -r "../c123-scoreboard-${{ needs.release-please.outputs.tag_name }}.zip" .
+
+      - name: Upload bundle to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
+            "c123-scoreboard-${{ needs.release-please.outputs.tag_name }}.zip" \
+            --repo "${{ github.repository }}"


### PR DESCRIPTION
Closes #87

## Co se mění

Přidává job `attach-bundle` do `release-please.yml`. Spustí se jen když release-please vytvoří release (`releases_created == true`):

1. `npm ci` + `npm run build` (Node 20)
2. zabalí `dist/` → `c123-scoreboard-<tag>.zip`
3. `gh release upload` nahraje zip jako asset

Scoreboard nemá privátní deps, takže job potřebuje jen `contents: write`.

## Vynucení releasu

Squash merge ponese `Release-As: 3.5.1`, aby se mechanismus ověřil end-to-end.

## Test plan

- [ ] Po mergi release PR v3.5.1: vznikne Release s assetem `c123-scoreboard-v3.5.1.zip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)