### PR TITLE
fix: align react and react-dom to 19.2.7 (error #527)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+    groups:
+      # react and react-dom must stay byte-identical (React runtime error #527),
+      # so always bump them together in a single PR.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -373,3 +373,15 @@ Font files added to `public/fonts/`, @font-face declarations in `fonts.css`.
 - Snapshots updated for new styles
 
 **Tag:** `v3.2.0`
+
+---
+
+## 2026-06-07 — react/react-dom version drift caused React error #527
+
+**Problem:** The dist bundle attached to release 3.5.1 crashed at runtime with [React error #527](https://react.dev/errors/527?args[]=19.2.7&args[]=19.2.6) — `react` resolved to 19.2.7 while `react-dom` stayed at 19.2.6. React requires both packages to be byte-identical at runtime.
+
+**Attempted:** Traced the mismatch in `package-lock.json`. Both 19.2.x patches were published on npm, so it wasn't a missing version — the lockfile simply held two different patches of the pair.
+
+**Solution:** Root cause was floating caret ranges (`^19.2.4` / `^19.2.6`) combined with dependabot historically bumping only `react-dom` (PRs #21/#73/#79). On lockfile regeneration `react` floated to the newest matching 19.2.7 while `react-dom` stayed pinned at 19.2.6. The `react-dom` peerDependency `^19.2.6` tolerates 19.2.7, so npm never complained — but React's runtime check demands an exact match. Fixed by pinning both to exact `19.2.7` (no caret) and adding a dependabot `groups` entry so the two always bump together in one PR (#90 / #91).
+
+**Lesson:** `react` and `react-dom` must be exact-pinned and version-locked together. A satisfied peerDependency range is *not* enough — React enforces byte-identical versions at runtime. Any package pair with a hard same-version coupling should be grouped in dependabot, never left on independent caret ranges.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "canoe-scoreboard-v2",
       "version": "3.5.1",
       "dependencies": {
-        "react": "^19.2.4",
-        "react-dom": "^19.2.6"
+        "react": "19.2.7",
+        "react-dom": "19.2.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -3685,15 +3685,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "test:visual": "playwright test cli-vs-c123.spec.ts --project=vertical"
   },
   "dependencies": {
-    "react": "^19.2.4",
-    "react-dom": "^19.2.6"
+    "react": "19.2.7",
+    "react-dom": "19.2.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",


### PR DESCRIPTION
Closes #90

## Co se dělo

Dist bundle u **release 3.5.1** padal na runtime chybu [React #527](https://react.dev/errors/527?args[]=19.2.7&args[]=19.2.6) — `react` (19.2.7) a `react-dom` (19.2.6) nebyly stejné verze. React vyžaduje, aby byly přesně identické.

## Root cause

Caret rozsahy (`^19.2.4` / `^19.2.6`) + dependabot bumpoval historicky jen `react-dom` (PR #21/#73/#79) → při regeneraci lockfile `react` doplaval na 19.2.7, `react-dom` zůstal na 19.2.6. peerDependency to tolerovala, runtime ne.

## Změny

- `package.json`: pin `react` i `react-dom` na **exact `19.2.7`** (bez `^`) → nemůžou driftovat.
- `package-lock.json`: regenerován, obě na 19.2.7.
- `.github/dependabot.yml`: `groups` pro `react` + `react-dom` → vždy bumpnuty v jednom PR.

## Test plan

- [x] `npm install` → lockfile má `react` i `react-dom` na 19.2.7
- [x] `npm run build` projde, dist vendor bundle obsahuje jen `19.2.7`
- [x] `npm test` → 764/764 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)